### PR TITLE
git api 주소를 동적으로 입력받을 수 있도록 수정

### DIFF
--- a/packages/figma-plugin/common/constants.ts
+++ b/packages/figma-plugin/common/constants.ts
@@ -1,8 +1,10 @@
 export const ACTION = {
+  GET_GITHUB_API_URL: "get-github-api-url",
   GET_GITHUB_REPO_URL: "get-github-repo-url",
   GET_GITHUB_API_KEY: "get-github-api-key",
   GET_ICON_PREVIEW: "get-icon-preview",
 
+  SET_GITHUB_API_URL: "set-github-api-url",
   SET_GITHUB_REPO_URL: "set-github-repo-url",
   SET_GITHUB_API_KEY: "set-github-api-key",
 
@@ -11,6 +13,7 @@ export const ACTION = {
 } as const;
 
 export const DATA = {
+  GITHUB_API_URL: "github-api-url",
   GITHUB_API_KEY: "github-api-key",
   GITHUB_REPO_URL: "github-repo-url",
 

--- a/packages/figma-plugin/common/types.ts
+++ b/packages/figma-plugin/common/types.ts
@@ -6,6 +6,7 @@ export interface GithubData {
   owner: string;
   name: string;
   apiKey: string;
+  apiUrl: string;
 }
 
 export interface IconaMetaData {
@@ -15,12 +16,14 @@ export interface IconaMetaData {
 export type Status = `${(typeof STATUS)[keyof typeof STATUS]}`;
 
 export type Messages =
+  | { type: `${typeof ACTION.GET_GITHUB_API_URL}`; payload: string }
   | { type: `${typeof ACTION.GET_GITHUB_API_KEY}`; payload: string }
   | { type: `${typeof ACTION.GET_GITHUB_REPO_URL}`; payload: string }
   | {
       type: `${typeof ACTION.GET_ICON_PREVIEW}`;
       payload: Record<string, IconaIconData>;
     }
+  | { type: `${typeof ACTION.SET_GITHUB_API_URL}`; payload: string }
   | { type: `${typeof ACTION.SET_GITHUB_API_KEY}`; payload: string }
   | { type: `${typeof ACTION.SET_GITHUB_REPO_URL}`; payload: string }
   | { type: `${typeof ACTION.DEPLOY_ICON}`; payload: IconaMetaData }

--- a/packages/figma-plugin/plugin-src/code.ts
+++ b/packages/figma-plugin/plugin-src/code.ts
@@ -22,6 +22,10 @@ async function setLocalData(key: string, data: any) {
 async function init() {
   const events = [
     {
+      data: DATA.GITHUB_API_URL,
+      type: ACTION.GET_GITHUB_API_URL,
+    },
+    {
       data: DATA.GITHUB_API_KEY,
       type: ACTION.GET_GITHUB_API_KEY,
     },
@@ -56,6 +60,11 @@ async function init() {
 
 figma.ui.onmessage = async (msg: Messages) => {
   switch (msg.type) {
+    case ACTION.SET_GITHUB_API_URL:
+      if (!msg.payload) return;
+      setLocalData(DATA.GITHUB_API_URL, msg.payload);
+      break;
+
     case ACTION.SET_GITHUB_REPO_URL:
       if (!msg.payload) return;
       setLocalData(DATA.GITHUB_REPO_URL, msg.payload);
@@ -74,8 +83,8 @@ figma.ui.onmessage = async (msg: Messages) => {
       const { githubData } = msg.payload;
 
       try {
-        const { owner, name, apiKey } = githubData;
-        const { createDeployPR } = createGithubClient(owner, name, apiKey);
+        const { owner, name, apiKey, apiUrl } = githubData;
+        const { createDeployPR } = createGithubClient(owner, name, apiKey, apiUrl);
         const iconaFrame = figma.currentPage.findOne((node) => {
           return node.name === DATA.ICON_FRAME_ID;
         });

--- a/packages/figma-plugin/plugin-src/github.ts
+++ b/packages/figma-plugin/plugin-src/github.ts
@@ -8,9 +8,10 @@ export function createGithubClient(
   repoOwner: string,
   repoName: string,
   accessToken: string,
+  apiUrl: string,
 ) {
   const ACCESS_TOKEN = accessToken;
-  const API_URL = `https://api.github.com/repos/${repoOwner}/${repoName}`;
+  const API_URL = apiUrl;
 
   async function uploadBlob(
     content: string,

--- a/packages/figma-plugin/ui-src/contexts/AppContext.tsx
+++ b/packages/figma-plugin/ui-src/contexts/AppContext.tsx
@@ -12,6 +12,7 @@ type State = {
   githubData: GithubData;
 
   // Input
+  githubApiUrl: string;
   githubRepositoryUrl: string;
   githubApiKey: string;
 
@@ -30,6 +31,15 @@ const AppDispatchContext = createContext<AppDispatch | null>(null);
 function reducer(state: State, action: Messages): State {
   switch (action.type) {
     /* GETTER */
+    case ACTION.GET_GITHUB_API_URL:
+      return {
+        ...state,
+        githubApiUrl: action.payload,
+        githubData: {
+          ...state.githubData,
+          apiUrl: action.payload,
+        },
+      };
     case ACTION.GET_GITHUB_API_KEY:
       return {
         ...state,
@@ -55,6 +65,19 @@ function reducer(state: State, action: Messages): State {
       };
 
     /* SETTER */
+    case ACTION.SET_GITHUB_API_URL:
+      postMessage({
+        type: action.type,
+        payload: action.payload,
+      });
+      return {
+        ...state,
+        githubApiUrl: action.payload,
+        githubData: {
+          ...state.githubData,
+          apiUrl: action.payload,
+        },
+      };
     case ACTION.SET_GITHUB_API_KEY:
       postMessage({
         type: action.type,
@@ -130,6 +153,9 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     window.onmessage = (event) => {
       const msg = event.data.pluginMessage as Messages;
       switch (msg.type) {
+        case ACTION.GET_GITHUB_API_URL:
+          if (msg.payload) dispatch({ type: msg.type, payload: msg.payload });
+          break;
         case ACTION.GET_GITHUB_API_KEY:
           if (msg.payload) dispatch({ type: msg.type, payload: msg.payload });
           break;

--- a/packages/figma-plugin/ui-src/pages/Setting.tsx
+++ b/packages/figma-plugin/ui-src/pages/Setting.tsx
@@ -10,16 +10,12 @@ import * as styles from "./Setting.css";
 
 const Setting = () => {
   const dispatch = useAppDispatch();
-  const { githubRepositoryUrl, githubApiKey } = useAppState();
-
-  const githubRepositoryUrlRegex = /https:\/\/github.com\/.*/;
-  const isErrorGithubRepositoryUrl =
-    githubRepositoryUrl.match(githubRepositoryUrlRegex) === null;
+  const { githubApiUrl, githubRepositoryUrl, githubApiKey } = useAppState();
   const isInvalidGithubApiKey = githubApiKey === "";
 
   const getProgress = () => {
-    if (isErrorGithubRepositoryUrl && isInvalidGithubApiKey) return 0;
-    if (isErrorGithubRepositoryUrl || isInvalidGithubApiKey) return 50;
+    if (isInvalidGithubApiKey) return 0;
+    if (isInvalidGithubApiKey) return 50;
     return 100;
   };
 
@@ -28,12 +24,27 @@ const Setting = () => {
       <Progress value={getProgress()} hasStripe colorScheme="blue" />
 
       <TextInput
+        label="Git API URL"
+        placeholder="Git API URL"
+        value={githubApiUrl}
+        helperText="Git API URL that you want to deploy."
+        errorMessage=""
+        isError={false}
+        handleChange={(event) => {
+          dispatch({
+            type: ACTION.SET_GITHUB_API_URL,
+            payload: event.target.value,
+          });
+        }}
+      />
+
+      <TextInput
         label="Github Repository URL"
         placeholder="Github Repository URL"
         value={githubRepositoryUrl}
         helperText="Github Repository URL that you want to deploy."
-        errorMessage="It's not a valid Github Repository URL."
-        isError={githubRepositoryUrl.match(/https:\/\/github.com\/.*/) === null}
+        errorMessage=""
+        isError={false}
         handleChange={(event) => {
           dispatch({
             type: ACTION.SET_GITHUB_REPO_URL,


### PR DESCRIPTION
## 추가 내용
- API 주소도 동적으로 입력받도록 수정
- GitHub repo만 사용하고 있는데, 해당 에러체크 제거

## 설명
- 플러그인 개발은 처음이라, 코드만 보고 수정했습니다 (테스트 못함)
- 해당 수정내용이 적용되지 못한다면, 해당 수정내용으로 별도 플러그인 등록을 해도 될까요? (git 엔터프라이즈에서 사용할 수 없어서요) @junghyeonsu


